### PR TITLE
Improved conversion of ndb.KeyProperty to GraphQL

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,11 @@
 History
 -------
 
-0.1.4 (TBD)
+0.1.5 (2016-06-08)
+---------------------
+* Fixed behavior of ndb.KeyProperty ([PR #14](https://github.com/graphql-python/graphene-gae/pull/14))
+
+0.1.4 (2016-06-02)
 ---------------------
 * NdbConnectionField added arguments that can be used in quert:
     * keys_only - to execute a keys only query
@@ -13,6 +17,7 @@ History
     * Given a property `ndb.LocalStructuredType(Something)` it will automatically
       map to a Field(SomethingType) - SomethingType has to be part of the schema.
     * Support for `repeated` and `required` propeties.
+
 
 0.1.3 (2016-05-27)
 ---------------------

--- a/graphene_gae/__init__.py
+++ b/graphene_gae/__init__.py
@@ -12,7 +12,7 @@ from .ndb.fields import (
 )
 
 __author__ = 'Eran Kampf'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 __all__ = [
     NdbObjectType,

--- a/graphene_gae/ndb/converter.py
+++ b/graphene_gae/ndb/converter.py
@@ -81,7 +81,8 @@ def convert_ndb_key_propety(ndb_key_prop, meta):
         resolved_prop_name = name[:-4] if name.endswith('_key') else p.plural(name[:-5])
     else:
         # Case #2 - name is of form 'store'
-        string_prop_name = name + '_keys' if ndb_key_prop._repeated else name + '_key'
+        singular_name = p.singular_noun(name) if p.singular_noun(name) else name
+        string_prop_name = singular_name + '_keys' if ndb_key_prop._repeated else singular_name + '_key'
         resolved_prop_name = name
 
     string_field = NdbKeyStringField(name)

--- a/graphene_gae/ndb/converter.py
+++ b/graphene_gae/ndb/converter.py
@@ -8,7 +8,7 @@ from graphene.core.types import Field
 from graphene.core.types.definitions import List
 from graphene.core.types.scalars import String, Boolean, Int, Float
 from graphene.core.types.custom_scalars import JSONString, DateTime
-from graphene_gae.ndb.fields import NdbKeyField
+from graphene_gae.ndb.fields import NdbKeyField, NdbKeyStringField
 
 __author__ = 'ekampf'
 
@@ -17,16 +17,16 @@ ConversionResult = namedtuple('ConversionResult', ['name', 'field'])
 p = inflect.engine()
 
 
-def convert_ndb_scalar_property(graphene_type, ndb_prop):
+def convert_ndb_scalar_property(graphene_type, ndb_prop, **kwargs):
     description = "%s %s property" % (ndb_prop._name, graphene_type)
+    result = graphene_type(description=description, **kwargs)
     if ndb_prop._repeated:
-        l = graphene_type(description=description).List
-        return l if not ndb_prop._required else l.NonNull
+        result = result.List
 
     if ndb_prop._required:
-        return graphene_type(description=description).NonNull
+        result = result.NonNull
 
-    return graphene_type(description=description)
+    return result
 
 
 def convert_ndb_string_property(ndb_prop, meta):
@@ -54,22 +54,68 @@ def convert_ndb_datetime_property(ndb_prop, meta):
 
 
 def convert_ndb_key_propety(ndb_key_prop, meta):
-    remove_key_suffix = meta.remove_key_property_suffix if meta else True
+    """
+    Two conventions for handling KeyProperties:
+    #1.
+        Given:
+            store_key = ndb.KeyProperty(...)
 
+        Result is 2 fields:
+            store_key = graphene.String() -> resolves to store_key.urlsafe()
+            store     = NdbKeyField()     -> resolves to entity
+
+    #2.
+        Given:
+            store = ndb.KeyProperty(...)
+
+        Result is 2 fields:
+            store_key = graphene.String() -> resolves to store_key.urlsafe()
+            store     = NdbKeyField()     -> resolves to entity
+
+    """
     name = ndb_key_prop._code_name
-    if remove_key_suffix:
-        if name.endswith('_key'):
-            name = name[:-4]
 
-        if name.endswith('_keys'):
-            name = name[:-5]
-            name = p.plural(name)
+    if name.endswith('_key') or name.endswith('_keys'):
+        # Case #1 - name is of form 'store_key' or 'store_keys'
+        string_prop_name = name
+        resolved_prop_name = name[:-4] if name.endswith('_key') else p.plural(name[:-5])
+    else:
+        # Case #2 - name is of form 'store'
+        string_prop_name = name + '_keys' if ndb_key_prop._repeated else name + '_key'
+        resolved_prop_name = name
 
-    field = NdbKeyField(ndb_key_prop._code_name, ndb_key_prop._kind)
+    string_field = NdbKeyStringField(name)
+    resolved_field = NdbKeyField(name, ndb_key_prop._kind)
+
     if ndb_key_prop._repeated:
-        field = field.List
+        string_field = string_field.List
+        resolved_field = resolved_field.List
 
-    return ConversionResult(name=name, field=field)
+    if ndb_key_prop._required:
+        string_field = string_field.NonNull
+        resolved_field = resolved_field.NonNull
+
+    string_key_field_result = ConversionResult(name=string_prop_name, field=string_field)
+    resolve_key_field_result = ConversionResult(name=resolved_prop_name, field=resolved_field)
+
+    return [
+        string_key_field_result,
+        resolve_key_field_result
+    ]
+
+    # if remove_key_suffix:
+    #     if name.endswith('_key'):
+    #         name = name[:-4]
+    #
+    #     if name.endswith('_keys'):
+    #         name = name[:-5]
+    #         name = p.plural(name)
+    #
+    # field = NdbKeyField(ndb_key_prop._code_name, ndb_key_prop._kind)
+    # if ndb_key_prop._repeated:
+    #     field = field.List
+    #
+    # return ConversionResult(name=name, field=field)
 
 
 def convert_local_structured_property(ndb_structured_prop, meta):
@@ -114,7 +160,7 @@ def convert_ndb_property(prop, meta=None):
     if not result:
         raise Exception("Failed to convert NDB field %s (%s)" % (prop._code_name, prop))
 
-    if isinstance(result, ConversionResult):
+    if isinstance(result, (list, ConversionResult,)):
         return result
 
     return ConversionResult(name=prop._code_name, field=result)

--- a/graphene_gae/ndb/fields.py
+++ b/graphene_gae/ndb/fields.py
@@ -150,30 +150,6 @@ class NdbKeyField(FieldType):
         key = getattr(entity, self.name)
 
         if isinstance(key, list):
-            return self.__auto_resolve_repeated(entity, key)
+            return ndb.get_multi(key)
 
-        return self.__auto_resolve_key(entity, key)
-
-    def __auto_resolve_repeated(self, entity, keys):
-        if not self.name.endswith('_keys'):
-            return ndb.get_multi(keys)
-
-        cache_name = self.name[:-4]  # TODO: pluralise
-        if hasattr(entity, cache_name):
-            return getattr(entity, cache_name)
-
-        values = ndb.get_multi(keys)
-        setattr(entity, cache_name, values)
-        return values
-
-    def __auto_resolve_key(self, entity, key):
-        if not self.name.endswith('_key'):
-            return key.get()
-
-        cache_name = self.name[:-4]
-        if hasattr(entity, cache_name):
-            return getattr(entity, cache_name)
-
-        value = key.get()
-        setattr(entity, cache_name, value)
-        return value
+        return key.get()

--- a/graphene_gae/ndb/fields.py
+++ b/graphene_gae/ndb/fields.py
@@ -105,7 +105,7 @@ class NdbKeyStringField(String):
         if isinstance(key, list):
             return [k.urlsafe() for k in key]
 
-        return key.urlsafe()
+        return key.urlsafe() if key else None
 
 
 class NdbKeyField(FieldType):
@@ -150,6 +150,7 @@ class NdbKeyField(FieldType):
         key = getattr(entity, self.name)
 
         if isinstance(key, list):
-            return ndb.get_multi(key)
+            entities = ndb.get_multi(key)
+            return entities
 
         return key.get()

--- a/graphene_gae/ndb/fields.py
+++ b/graphene_gae/ndb/fields.py
@@ -4,7 +4,7 @@ from google.appengine.ext.db import BadArgumentError
 from graphene import relay
 from graphene.core.exceptions import SkipField
 from graphene.core.types.base import FieldType
-from graphene.core.types.scalars import Boolean, Int
+from graphene.core.types.scalars import Boolean, Int, String
 
 __author__ = 'ekampf'
 
@@ -87,6 +87,25 @@ class NdbConnectionField(relay.ConnectionField):
     @property
     def model(self):
         return self.type._meta.model
+
+
+class NdbKeyStringField(String):
+    def __init__(self, name, *args, **kwargs):
+        self.name = name
+
+        if 'resolver' not in kwargs:
+            kwargs['resolver'] = self.default_resolver
+
+        super(NdbKeyStringField, self).__init__(*args, **kwargs)
+
+    def default_resolver(self, node, args, info):
+        entity = node.instance
+        key = getattr(entity, self.name)
+
+        if isinstance(key, list):
+            return [k.urlsafe() for k in key]
+
+        return key.urlsafe()
 
 
 class NdbKeyField(FieldType):

--- a/graphene_gae/ndb/fields.py
+++ b/graphene_gae/ndb/fields.py
@@ -126,7 +126,7 @@ class NdbKeyField(FieldType):
                 "You can either register the type manually "
                 "using @schema.register. "
                 "Or disable the field in %s" % (
-                    self.model,
+                    self.kind,
                     self.parent,
                 )
             )

--- a/graphene_gae/ndb/options.py
+++ b/graphene_gae/ndb/options.py
@@ -11,9 +11,6 @@ class NdbOptions(ObjectTypeOptions):
     * model - which model to convert
     * only_fields - only convert the following property names
     * exclude_fields - exclude specified properties from conversion
-    * remove_key_property_suffix - remove '_key' suffix from KeyProperty
-        * user_key => user
-        * user_keys => users
 
     """
 
@@ -25,7 +22,6 @@ class NdbOptions(ObjectTypeOptions):
         self.valid_attrs += self.VALID_ATTRS
         self.only_fields = None
         self.exclude_fields = []
-        self.remove_key_property_suffix = True
 
     def contribute_to_class(self, cls, name):
         super(NdbOptions, self).contribute_to_class(cls, name)

--- a/graphene_gae/ndb/types.py
+++ b/graphene_gae/ndb/types.py
@@ -31,8 +31,12 @@ class NdbObjectTypeMeta(ObjectTypeMeta):
             if is_not_in_only or is_excluded:
                 continue
 
-            conversion_result = convert_ndb_property(prop, cls._meta)
-            cls.add_to_class(conversion_result.name, conversion_result.field)
+            conversion_results = convert_ndb_property(prop, cls._meta)
+            if not isinstance(conversion_results, list):
+                conversion_results = [conversion_results]
+
+            for r in conversion_results:
+                cls.add_to_class(r.name, r.field)
 
     def construct(cls, *args, **kwargs):
         super(NdbObjectTypeMeta, cls).construct(*args, **kwargs)

--- a/tests/_ndb/test_converter.py
+++ b/tests/_ndb/test_converter.py
@@ -121,7 +121,6 @@ class TestNDBConverter(BaseTest):
         self.assertIsInstance(conversion[1].field, NonNull)
         self.assertIsInstance(conversion[1].field.of_type, NdbKeyField)
 
-
     def testKeyProperty_withoutSuffix(self):
         prop = ndb.KeyProperty()
         prop._code_name = 'user'

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -273,3 +273,36 @@ class TestNDBTypes(BaseTest):
         author = dict(article['author'])
         self.assertDictEqual(author, {'name': u'john dow', 'email': u'john@dow.com'})
         self.assertDictContainsSubset(dict(headline='h1', authorKey=author_key.urlsafe()), article)
+
+
+    def testQuery_repeatedKeyProperty(self):
+        tk1 = Tag(name="t1").put()
+        tk2 = Tag(name="t2").put()
+        tk3 = Tag(name="t3").put()
+        tk4 = Tag(name="t4").put()
+        Article(headline="h1", summary="s1", tags=[tk1, tk2, tk3, tk4]).put()
+
+        print str(schema)
+
+        result = schema.execute('''
+            query ArticleWithAuthorID {
+                articles {
+                    headline
+                    authorKey
+                    tagKeys
+                    tags {
+                        name
+                    }
+                }
+            }
+        ''')
+
+        self.assertEmpty(result.errors)
+
+        article = dict(result.data['articles'][0])
+        self.assertListEqual(map(lambda k: k.urlsafe(), [tk1, tk2, tk3, tk4]), article['tagKeys'])
+
+        self.assertLength(article['tags'], 4)
+        for i in range(0, 3):
+            self.assertEqual(article['tags'][i]['name'], 't%s' % (i+1))
+

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -274,7 +274,6 @@ class TestNDBTypes(BaseTest):
         self.assertDictEqual(author, {'name': u'john dow', 'email': u'john@dow.com'})
         self.assertDictContainsSubset(dict(headline='h1', authorKey=author_key.urlsafe()), article)
 
-
     def testQuery_repeatedKeyProperty(self):
         tk1 = Tag(name="t1").put()
         tk2 = Tag(name="t2").put()
@@ -304,5 +303,5 @@ class TestNDBTypes(BaseTest):
 
         self.assertLength(article['tags'], 4)
         for i in range(0, 3):
-            self.assertEqual(article['tags'][i]['name'], 't%s' % (i+1))
+            self.assertEqual(article['tags'][i]['name'], 't%s' % (i + 1))
 

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -103,7 +103,7 @@ class TestNDBTypes(BaseTest):
         article = dict(result.data['articles'][0])
         author = dict(article['author'])
         self.assertDictEqual(author, {'name': u'john dow', 'email': u'john@dow.com'})
-        self.assertDictContainsSubset(dict(headline='h1', summary='s1', authorKey=author_key.urlsafe()), article)
+        self.assertDictContainsSubset(dict(headline='h1', authorKey=author_key.urlsafe()), article)
 
 
 

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -99,7 +99,7 @@ class TestNDBTypes(BaseTest):
                     return Article.query()
 
             schema = graphene.Schema(query=QueryType)
-            result = schema.execute('query test {  articles { prop } }')
+            schema.execute('query test {  articles { prop } }')
 
         self.assertIn("Model 'bar' is not accessible by the schema.", str(context.exception.message))
 

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -86,7 +86,6 @@ class TestNDBTypes(BaseTest):
         author_key = Author(name="john dow", email="john@dow.com").put()
         Article(headline="h1", summary="s1", author_key=author_key).put()
 
-        print str(schema)
         result = schema.execute('''
             query ArticleWithAuthorID {
                 articles {

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -82,31 +82,6 @@ class TestNDBTypes(BaseTest):
 
         assert 'not an NDB model' in str(context.exception.message)
 
-    def testNdbKeyField_whenOnlyIDRequested_doesntQueryEntity(self):
-        author_key = Author(name="john dow", email="john@dow.com").put()
-        Article(headline="h1", summary="s1", author_key=author_key).put()
-
-        result = schema.execute('''
-            query ArticleWithAuthorID {
-                articles {
-                    headline
-                    authorKey
-                    author {
-                        name, email
-                    }
-                }
-            }
-        ''')
-
-        self.assertEmpty(result.errors)
-
-        article = dict(result.data['articles'][0])
-        author = dict(article['author'])
-        self.assertDictEqual(author, {'name': u'john dow', 'email': u'john@dow.com'})
-        self.assertDictContainsSubset(dict(headline='h1', authorKey=author_key.urlsafe()), article)
-
-
-
     def testQuery_excludedField(self):
         Article(headline="h1", summary="s1").put()
 
@@ -275,3 +250,26 @@ class TestNDBTypes(BaseTest):
         addresses = [dict(d) for d in author["addresses"]]
         self.assertIn(address1.to_dict(), addresses)
         self.assertIn(address2.to_dict(), addresses)
+
+    def testQuery_keyProperty(self):
+        author_key = Author(name="john dow", email="john@dow.com").put()
+        Article(headline="h1", summary="s1", author_key=author_key).put()
+
+        result = schema.execute('''
+            query ArticleWithAuthorID {
+                articles {
+                    headline
+                    authorKey
+                    author {
+                        name, email
+                    }
+                }
+            }
+        ''')
+
+        self.assertEmpty(result.errors)
+
+        article = dict(result.data['articles'][0])
+        author = dict(article['author'])
+        self.assertDictEqual(author, {'name': u'john dow', 'email': u'john@dow.com'})
+        self.assertDictContainsSubset(dict(headline='h1', authorKey=author_key.urlsafe()), article)

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -2,7 +2,7 @@ from tests.base_test import BaseTest
 
 import graphene
 
-from graphene_gae import NdbObjectType
+from graphene_gae import NdbObjectType, NdbKeyField
 from tests.models import Tag, Comment, Article, Address, Author, PhoneNumber
 
 __author__ = 'ekampf'
@@ -81,6 +81,27 @@ class TestNDBTypes(BaseTest):
                     model = 1
 
         assert 'not an NDB model' in str(context.exception.message)
+
+    def testNdbObjectType_keyProperty_kindDoesntExist_raisesException(self):
+        with self.assertRaises(Exception) as context:
+            class ArticleType(NdbObjectType):
+                class Meta:
+                    model = Article
+                    only_fields = ('prop',)
+
+                prop = NdbKeyField('foo', 'bar')
+
+            class QueryType(graphene.ObjectType):
+                articles = graphene.List(ArticleType)
+
+                @graphene.resolve_only_args
+                def resolve_articles(self):
+                    return Article.query()
+
+            schema = graphene.Schema(query=QueryType)
+            result = schema.execute('query test {  articles { prop } }')
+
+        self.assertIn("Model 'bar' is not accessible by the schema.", str(context.exception.message))
 
     def testQuery_excludedField(self):
         Article(headline="h1", summary="s1").put()


### PR DESCRIPTION
Basically we want to allow 2 ways of accessing a key's values.
1. Access the key's actual value without querying NDB - we'll just use `key.urlsafe()`
2. Resolve the key to an entity and query that entity - `key.get()`

We support 2 naming conventions:

## _key or _keys Suffix
NDB Model has a property that looks like this: ```store_key = ndb.KeyProperty(...)```
In this case we'll convert it into the following 2 GraphQL fields:
```
store_key = graphene.String()  # resolves to entity.store_key.urlsafe()
store = NdbKeyField()  # resolves to entity entity.store_key.get()
```

## Regular Name
NDB Model has a property that looks like this: ```store = ndb.KeyProperty(...)```
In this case we'll convert it into the following 2 GraphQL fields:
```
store_key = graphene.String() -> resolves to store_key.urlsafe()
store     = NdbKeyField()     -> resolves to entity
```