### PR TITLE
Breaking change: ndb KeyProperties should be externalised as Global IDs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+0.1.7 (TBD)
+---------------------
+
+
 0.1.6 (2016-06-10)
 ---------------------
 * Changing development status to Beta

--- a/graphene_gae/__init__.py
+++ b/graphene_gae/__init__.py
@@ -12,7 +12,7 @@ from .ndb.fields import (
 )
 
 __author__ = 'Eran Kampf'
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 __all__ = [
     NdbObjectType,

--- a/graphene_gae/ndb/converter.py
+++ b/graphene_gae/ndb/converter.py
@@ -90,7 +90,7 @@ def convert_ndb_key_propety(ndb_key_prop, meta):
         string_prop_name = singular_name + '_ids' if ndb_key_prop._repeated else singular_name + '_id'
         resolved_prop_name = name
 
-    string_field = NdbKeyStringField(name)
+    string_field = NdbKeyStringField(name, ndb_key_prop._kind)
     resolved_field = NdbKeyField(name, ndb_key_prop._kind)
 
     if ndb_key_prop._repeated:

--- a/graphene_gae/ndb/fields.py
+++ b/graphene_gae/ndb/fields.py
@@ -91,13 +91,42 @@ class NdbConnectionField(relay.ConnectionField):
 
 
 class NdbKeyStringField(String):
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, kind, *args, **kwargs):
         self.name = name
+        self.kind = kind
 
         if 'resolver' not in kwargs:
             kwargs['resolver'] = self.default_resolver
 
         super(NdbKeyStringField, self).__init__(*args, **kwargs)
+
+    def internal_type(self, schema):
+        _type = self.get_object_type(schema)
+        if not _type and self.parent._meta.only_fields:
+            raise Exception(
+                "Model %r is not accessible by the schema. "
+                "You can either register the type manually "
+                "using @schema.register. "
+                "Or disable the field in %s" % (
+                    self.kind,
+                    self.parent,
+                )
+            )
+
+        if not _type:
+            raise SkipField()
+
+        from graphql import GraphQLString
+        return GraphQLString
+
+    def get_object_type(self, schema):
+        for _type in schema.types.values():
+            type_model = hasattr(_type, '_meta') and getattr(_type._meta, 'model', None)
+            if not type_model:
+                continue
+
+            if self.kind == type_model or self.kind == type_model.__name__:
+                return _type
 
     def default_resolver(self, node, args, info):
         entity = node.instance
@@ -106,38 +135,11 @@ class NdbKeyStringField(String):
             return None
 
         if isinstance(key, list):
-            t = self.__get_key_internal_type(key[0], info.schema.graphene_schema)
-            return [to_global_id(t.name, k.urlsafe()) for k in key]
+            t = self.get_object_type(info.schema.graphene_schema)._meta.type_name
+            return [to_global_id(t, k.urlsafe()) for k in key]
 
-        t = self.__get_key_internal_type(key, info.schema.graphene_schema)
-        return to_global_id(t.name, key.urlsafe()) if key else None
-
-    def __get_key_internal_type(self, key, schema):
-        _type = self.__find_key_object_type(key, schema)
-        if not _type and self.parent._meta.only_fields:
-            raise Exception(
-                "Model %r is not accessible by the schema. "
-                "You can either register the type manually "
-                "using @schema.register. "
-                "Or disable the field in %s" % (
-                    key.kind(),
-                    self.parent,
-                )
-            )
-
-        if not _type:
-            raise SkipField()
-
-        return schema.T(_type)
-
-    def __find_key_object_type(self, key, schema):
-        for _type in schema.types.values():
-            type_model = hasattr(_type, '_meta') and getattr(_type._meta, 'model', None)
-            if not type_model:
-                continue
-
-            if key.kind() == type_model or key.kind() == type_model.__name__:
-                return _type
+        t = self.get_object_type(info.schema.graphene_schema)._meta.type_name
+        return to_global_id(t, key.urlsafe()) if key else None
 
 
 class NdbKeyField(FieldType):

--- a/tests/_ndb/test_converter.py
+++ b/tests/_ndb/test_converter.py
@@ -83,7 +83,7 @@ class TestNDBConverter(BaseTest):
 
         self.assertLength(conversion, 2)
 
-        self.assertEqual(conversion[0].name, 'user_key')
+        self.assertEqual(conversion[0].name, 'user_id')
         self.assertIsInstance(conversion[0].field, NdbKeyStringField)
 
         self.assertEqual(conversion[1].name, 'user')
@@ -97,7 +97,7 @@ class TestNDBConverter(BaseTest):
 
         self.assertLength(conversion, 2)
 
-        self.assertEqual(conversion[0].name, 'user_keys')
+        self.assertEqual(conversion[0].name, 'user_ids')
         self.assertIsInstance(conversion[0].field, List)
         self.assertIsInstance(conversion[0].field.of_type, NdbKeyStringField)
 
@@ -113,7 +113,7 @@ class TestNDBConverter(BaseTest):
 
         self.assertLength(conversion, 2)
 
-        self.assertEqual(conversion[0].name, 'user_key')
+        self.assertEqual(conversion[0].name, 'user_id')
         self.assertIsInstance(conversion[0].field, NonNull)
         self.assertIsInstance(conversion[0].field.of_type, NdbKeyStringField)
 
@@ -129,7 +129,7 @@ class TestNDBConverter(BaseTest):
 
         self.assertLength(conversion, 2)
 
-        self.assertEqual(conversion[0].name, 'user_key')
+        self.assertEqual(conversion[0].name, 'user_id')
         self.assertIsInstance(conversion[0].field, NdbKeyStringField)
 
         self.assertEqual(conversion[1].name, 'user')

--- a/tests/_ndb/test_types.py
+++ b/tests/_ndb/test_types.py
@@ -122,7 +122,7 @@ class TestNDBTypes(BaseTest):
                     return Article.query()
 
             schema = graphene.Schema(query=QueryType)
-            result = schema.execute('query test {  articles { prop } }')
+            schema.execute('query test {  articles { prop } }')
 
         self.assertIn("Model 'bar' is not accessible by the schema.", str(context.exception.message))
 

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -61,7 +61,7 @@ class BaseTest(unittest.TestCase):
 
     # region Extra Assertions
     def assertEmpty(self, l, msg=None):
-        self.assertEqual(0, len(list(l)), msg=msg)
+        self.assertEqual(0, len(list(l)), msg=msg or str(l))
 
     def assertLength(self, l, expectation, msg=None):
         self.assertEqual(len(l), expectation, msg)


### PR DESCRIPTION
We should never externalise internal NDB key values. It doesn't make sense.
GraphQL Nodes IDs are in a *global_id* format (a base64 encoded <graphql type name>:<internal id>).
It only makes sense that model properties that expose ids of other objects use the same format.

Otherwise the APIs consumer will have to know when to convert from global_id to key and the opposite.