### PR TITLE
Feature/handle errors in handler

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 History
 -------
+1.0.2 (2016-10-20)
+------------------
+* Added `_handle_graphql_errors` hook to GraphQLHandler
 
 1.0.1 (2016-09-28)
 ------------------

--- a/graphene_gae/__init__.py
+++ b/graphene_gae/__init__.py
@@ -9,7 +9,7 @@ from .ndb.fields import (
 )
 
 __author__ = 'Eran Kampf'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 __all__ = [
     NdbObjectType,

--- a/graphene_gae/webapp2/__init__.py
+++ b/graphene_gae/webapp2/__init__.py
@@ -25,8 +25,6 @@ class GraphQLHandler(webapp2.RequestHandler):
                                 context_value=self._get_context(),
                                 root_value=self._get_root_value())
 
-
-
         response = {}
         if result.errors:
             response['errors'] = [self.__format_error(e) for e in result.errors]

--- a/graphene_gae/webapp2/__init__.py
+++ b/graphene_gae/webapp2/__init__.py
@@ -25,10 +25,13 @@ class GraphQLHandler(webapp2.RequestHandler):
                                 context_value=self._get_context(),
                                 root_value=self._get_root_value())
 
+
+
         response = {}
         if result.errors:
             response['errors'] = [self.__format_error(e) for e in result.errors]
             logging.warn("Request had errors: %s", response)
+            self._handle_graphql_errors(result.errors)
 
         if result.invalid:
             logging.error("GraphQL request is invalid: %s", response)
@@ -47,6 +50,9 @@ class GraphQLHandler(webapp2.RequestHandler):
         self.failed_response(status_code, {
             'errors': [self.__format_error(exception)]
         })
+
+    def _handle_graphql_errors(self, result):
+        pass
 
     def _get_schema(self):
         return self.app.config.get('graphql_schema')

--- a/tests/_webapp2/test_graphql_handler.py
+++ b/tests/_webapp2/test_graphql_handler.py
@@ -14,14 +14,14 @@ class QueryRootType(graphene.ObjectType):
     default_greet = 'World'
 
     greet = graphene.Field(graphene.String, who=graphene.Argument(graphene.String))
-    resolverRaises = graphene.String()
+    resolver_raises = graphene.String()
 
     @graphene.resolve_only_args
     def resolve_greet(self, who):
         return 'Hello %s!' % who
 
     def resolve_resolver_raises(self, *_):
-        raise Exception()
+        raise Exception("TEST")
 
 
 class ChangeDefaultGreetingMutation(relay.ClientIDMutation):
@@ -189,3 +189,4 @@ class TestGraphQLHandler(BaseTest):
     def testPOST_stringBody_readsQueryFromBodyAndRestFromGET(self):
         response = self.app.post('/graphql?pretty=True', params='query helloYou { greet(who: "You") }')
         self.assertEqual(response.body, '{\n  "data": {\n    "greet": "Hello You!"\n  }\n}')
+


### PR DESCRIPTION
Added a `_handle_graphql_errors(errors)` hook to GraphQLHandle allowing processing errors after graphql finished execution.

The use case for this is that sometimes we want to turn certain GraphQL errors into http errors.
Forexample if we're doing authentication login in the resolvers and want to convert authentication errors to 401 status response.