### PR TITLE
Support for mapping\filtering entities in ndb connection field

### DIFF
--- a/tests/_ndb/test_types_relay.py
+++ b/tests/_ndb/test_types_relay.py
@@ -50,11 +50,11 @@ class CommentType(NdbObjectType):
         interfaces = (Node,)
 
 
-def readers_mapper(article_readers, args, **kwargs):
+def readers_mapper(article_readers, args, context):
     return ndb.get_multi([article_reader.reader_key for article_reader in article_readers])
 
 
-def reader_filter(reader, args, **kwargs):
+def reader_filter(reader, args, context):
     return reader.is_alive
 
 

--- a/tests/_webapp2/test_graphql_handler.py
+++ b/tests/_webapp2/test_graphql_handler.py
@@ -40,6 +40,7 @@ class ChangeDefaultGreetingMutation(relay.ClientIDMutation):
 class MutationRootType(graphene.ObjectType):
     changeDefaultGreeting = ChangeDefaultGreetingMutation.Field()
 
+
 schema = graphene.Schema(query=QueryRootType, mutation=MutationRootType)
 
 graphql_application.config['graphql_schema'] = schema

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,11 @@ class PhoneNumber(ndb.Model):
     number = ndb.StringProperty()
 
 
+class Reader(ndb.Model):
+    name = ndb.StringProperty()
+    email = ndb.StringProperty()
+
+
 class Author(ndb.Model):
     name = ndb.StringProperty()
     email = ndb.StringProperty()
@@ -29,6 +34,13 @@ class Comment(ndb.Model):
     created_at = ndb.DateTimeProperty(auto_now_add=True)
     updated_at = ndb.DateTimeProperty(auto_now=True)
     body = ndb.StringProperty()
+
+
+class ArticleReader(ndb.Model):
+    article_key = ndb.KeyProperty(kind='Article')
+    reader_key = ndb.KeyProperty(kind='Reader')
+
+    read_at = ndb.DateTimeProperty(auto_now_add=True)
 
 
 class Article(ndb.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -17,6 +17,7 @@ class PhoneNumber(ndb.Model):
 class Reader(ndb.Model):
     name = ndb.StringProperty()
     email = ndb.StringProperty()
+    is_alive = ndb.BooleanProperty(default=True)
 
 
 class Author(ndb.Model):


### PR DESCRIPTION
This PR contains support for post NDB query interference to achieve mapping and filtering of entities fetched by NDB queries resolved within NDBConnectionFields.

It's very useful in situations where there's a many to many relation between two NDB models and you need to paginate over them.
See the added tests for an example.

Example explained -
A new `Reader` model was added. Each reader may have read multiple articles, and each article may have been read by multiple readers. The many to many relation is implemented using the `ArticleReader` model which represents that some reader has read an article and contains the reader key and article key.
Now, in order to paginate over all the article readers, the `readers` property was added to `ArticleType`:
`readers = NdbConnectionField(ReaderType, entities_mapper=readers_mapper, entity_filter=reader_filter)`
Notice that `ArticleType`'s `resolve_readers` returns a query for all the `ArticleReader` entities.
Upon resolving it `readers_mapper` is called and maps each article reader to the appropriate reader.
Later we filter the readers in `reader_filter` and only return the readers that are alive.
