### PR TITLE
GraphQLHandler: GET requests

### DIFF
--- a/graphene_gae/webapp2/__init__.py
+++ b/graphene_gae/webapp2/__init__.py
@@ -9,7 +9,13 @@ __author__ = 'ekampf'
 
 
 class GraphQLHandler(webapp2.RequestHandler):
+    def get(self):
+        return self._handle_request()
+
     def post(self):
+        return self._handle_request()
+
+    def _handle_request(self):
         schema = self._get_schema()
         pretty = self._get_pretty()
 

--- a/tests/_webapp2/test_graphql_handler.py
+++ b/tests/_webapp2/test_graphql_handler.py
@@ -53,40 +53,62 @@ class TestGraphQLHandler(BaseTest):
 
         self.app = webtest.TestApp(graphql_application)
 
-    def testPOST_noSchema_returns500(self):
+    def get(self, *args, **kwargs):
+        return self.app.get(*args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        if 'params' in kwargs:
+            kwargs['params'] = json.dumps(kwargs['params'])
+        return self.app.post(*args, **kwargs)
+
+    def test_noSchema_returns500(self):
         graphql_application = webapp2.WSGIApplication([
             ('/graphql', GraphQLHandler)
         ])
 
         app = webtest.TestApp(graphql_application)
-        response = app.post('/graphql', expect_errors=True)
-        self.assertEqual(response.status_int, 500)
-        self.assertEqual(response.json_body['errors'][0]['message'], 'GraphQL Schema is missing.')
+        for method in (app.get, app.post):
+            response = method('/graphql', expect_errors=True)
+            self.assertEqual(response.status_int, 500)
+            self.assertEqual(response.json_body['errors'][0]['message'], 'GraphQL Schema is missing.')
 
-    def testPOST_noInput_returns400(self):
-        response = self.app.post('/graphql', expect_errors=True)
-        self.assertEqual(response.status_int, 400)
+    def test_noInput_returns400(self):
+        for method in (self.app.get, self.app.post):
+            response = method('/graphql', expect_errors=True)
+            self.assertEqual(response.status_int, 400)
 
-    def testPost_supports_operation_name(self):
-        response = self.app.post('/graphql', params=json.dumps(dict(
-            query='''
-                query helloYou { greet(who: "You"), ...shared }
-                query helloWorld { greet(who: "World"), ...shared }
-                query helloDolly { greet(who: "Dolly"), ...shared }
-                fragment shared on QueryRootType {
-                    shared: greet(who: "Everyone")
+    def test_supports_operation_name(self):
+        for method in (self.get, self.post):
+            response = method('/graphql', params=dict(
+                query='''
+                    query helloYou { greet(who: "You"), ...shared }
+                    query helloWorld { greet(who: "World"), ...shared }
+                    query helloDolly { greet(who: "Dolly"), ...shared }
+                    fragment shared on QueryRootType {
+                        shared: greet(who: "Everyone")
+                    }
+                ''',
+                operation_name='helloDolly'
+            ))
+
+            response_dict = json.loads(response.body)
+            self.assertDictEqual(
+                response_dict.get('data'),
+                {
+                    'greet': 'Hello Dolly!',
+                    'shared': 'Hello Everyone!'
                 }
-            ''',
-            operation_name='helloDolly'
-        )))
+            )
+
+    def testGET_support_json_variables(self):
+        response = self.app.get('/graphql', params=dict(
+            query='query helloWho($who: String){ greet(who: $who) }',
+            variables=json.dumps({'who': "ekampf"})
+        ))
 
         response_dict = json.loads(response.body)
         self.assertDictEqual(
-            response_dict.get('data'),
-            {
-                'greet': 'Hello Dolly!',
-                'shared': 'Hello Everyone!'
-            }
+            response_dict.get('data'), {'greet': 'Hello ekampf!'}
         )
 
     def testPOST_support_json_variables(self):
@@ -100,62 +122,80 @@ class TestGraphQLHandler(BaseTest):
             response_dict.get('data'), {'greet': 'Hello ekampf!'}
         )
 
-    def testPOST_reports_argument_validation_errors(self):
-        response = self.app.post('/graphql', expect_errors=True, params=json.dumps(dict(
+    def test_reports_argument_validation_errors(self):
+        for method in (self.get, self.post):
+            response = method('/graphql', expect_errors=True, params=dict(
+                query='''
+                    query helloYou { greet(who: 123), ...shared }
+                    query helloWorld { greet(who: "World"), ...shared }
+                    query helloDolly { greet(who: "Dolly"), ...shared }
+                    fragment shared on Query {
+                        shared: greet(who: "Everyone")
+                    }
+                ''',
+                operation_name='helloYou'
+            ))
+
+            self.assertEqual(response.status_int, 400)
+
+            response_dict = json.loads(response.body)
+            self.assertEqual(response_dict["errors"][0]["message"], "Argument \"who\" has invalid value 123.\nExpected type \"String\", found 123.")
+
+    def test_reports_missing_operation_name(self):
+        for method in (self.get, self.post):
+            response = method('/graphql', expect_errors=True, params=dict(
+                query='''
+                    query helloWorld { greet(who: "World"), ...shared }
+                    query helloDolly { greet(who: "Dolly"), ...shared }
+                    fragment shared on QueryRootType {
+                        shared: greet(who: "Everyone")
+                    }
+                '''
+            ))
+
+            self.assertEqual(response.status_int, 400)
+
+            response_dict = json.loads(response.body)
+            self.assertEqual(response_dict["errors"][0]["message"], "Must provide operation name if query contains multiple operations.")
+
+    def test_handles_syntax_errors(self):
+        for method in (self.get, self.post):
+            response = method('/graphql', expect_errors=True, params=dict(query='syntaxerror'))
+
+            self.assertEqual(response.status_int, 400)
+
+            expected = {
+                'errors': [{'locations': [{'column': 1, 'line': 1}],
+                            'message': 'Syntax Error GraphQL request (1:1) '
+                                       'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n'}]
+            }
+            response_dict = json.loads(response.body)
+            self.assertEqual(response_dict, expected)
+
+    def test_handles_poorly_formed_variables(self):
+        for method in (self.get, self.post):
+            response = method('/graphql', expect_errors=True, params=dict(
+                query='query helloWho($who: String){ greet(who: $who) }',
+                variables='who:You'
+            ))
+
+            response_data = json.loads(response.body)
+            self.assertEqual(response.status_int, 400)
+            self.assertEqual(response_data['errors'][0]['message'], 'Variables are invalid JSON.')
+
+    def testGET_mutations(self):
+        response = self.app.get('/graphql', params=dict(
             query='''
-                query helloYou { greet(who: 123), ...shared }
-                query helloWorld { greet(who: "World"), ...shared }
-                query helloDolly { greet(who: "Dolly"), ...shared }
-                fragment shared on Query {
-                    shared: greet(who: "Everyone")
+            mutation TestMutatio  {
+                changeDefaultGreeting(input: { value: "universe" } ) {
+                    ok,
+                    defaultGreeting
                 }
-            ''',
-            operation_name='helloYou'
-        )))
+            }'''
+        ))
 
-        self.assertEqual(response.status_int, 400)
-
-        response_dict = json.loads(response.body)
-        self.assertEqual(response_dict["errors"][0]["message"], "Argument \"who\" has invalid value 123.\nExpected type \"String\", found 123.")
-
-    def testPOST_reports_missing_operation_name(self):
-        response = self.app.post('/graphql', expect_errors=True, params=json.dumps(dict(
-            query='''
-                query helloWorld { greet(who: "World"), ...shared }
-                query helloDolly { greet(who: "Dolly"), ...shared }
-                fragment shared on QueryRootType {
-                    shared: greet(who: "Everyone")
-                }
-            '''
-        )))
-
-        self.assertEqual(response.status_int, 400)
-
-        response_dict = json.loads(response.body)
-        self.assertEqual(response_dict["errors"][0]["message"], "Must provide operation name if query contains multiple operations.")
-
-    def testPOST_handles_syntax_errors(self):
-        response = self.app.post('/graphql', expect_errors=True, params=json.dumps(dict(query='syntaxerror')))
-
-        self.assertEqual(response.status_int, 400)
-
-        expected = {
-            'errors': [{'locations': [{'column': 1, 'line': 1}],
-                        'message': 'Syntax Error GraphQL request (1:1) '
-                                   'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n'}]
-        }
-        response_dict = json.loads(response.body)
-        self.assertEqual(response_dict, expected)
-
-    def testPOST_handles_poorly_formed_variables(self):
-        response = self.app.post('/graphql', expect_errors=True, params=json.dumps(dict(
-            query='query helloWho($who: String){ greet(who: $who) }',
-            variables='who:You'
-        )))
-
-        response_data = json.loads(response.body)
-        self.assertEqual(response.status_int, 400)
-        self.assertEqual(response_data['errors'][0]['message'], 'Variables are invalid JSON.')
+        self.assertEqual('universe', response.json_body['data']['changeDefaultGreeting']['defaultGreeting'])
+        self.assertEqual(True, response.json_body['data']['changeDefaultGreeting']['ok'])
 
     def testPOST_mutations(self):
         response = self.app.post('/graphql',


### PR DESCRIPTION
Hello! Since handling query parameters is already done for POST requests in `GraphQLHandler`, it seems like we could trivially do GET requests. So, here that is!

I've augmented all relevant tests to test GET as well as POST.

I'm new to GraphQL but it seems kinda funny to accept mutations via an HTTP GET?