### PR TITLE
Fix for PolyModel type lookup

### DIFF
--- a/graphene_gae/ndb/types.py
+++ b/graphene_gae/ndb/types.py
@@ -113,10 +113,10 @@ class NdbObjectType(ObjectType):
 
         # Returns True if `root` is a PolyModel subclass and `cls` is in the
         # class hierarchy of `root` which is retrieved with `_class_key`
-        if (hasattr(root, '_class_key')
-                and hasattr(cls._meta.model, '_class_key')
-                and set(cls._meta.model._class_key()).issubset(
-                    set(root._class_key()))):
+        if (hasattr(root, '_class_key') and
+            hasattr(cls._meta.model, '_class_key') and
+            set(cls._meta.model._class_key()).issubset(
+                set(root._class_key()))):
             return True
 
         return type(root) == cls._meta.model

--- a/graphene_gae/ndb/types.py
+++ b/graphene_gae/ndb/types.py
@@ -113,7 +113,10 @@ class NdbObjectType(ObjectType):
 
         # Returns True if `root` is a PolyModel subclass and `cls` is in the
         # class hierarchy of `root` which is retrieved with `_class_key`
-        if hasattr(root, '_class_key') and cls._meta.model._get_kind() in root._class_key():
+        if (hasattr(root, '_class_key')
+                and hasattr(cls._meta.model, '_class_key')
+                and set(cls._meta.model._class_key()).issubset(
+                    set(root._class_key()))):
             return True
 
         return type(root) == cls._meta.model

--- a/tests/_webapp2/test_graphql_handler.py
+++ b/tests/_webapp2/test_graphql_handler.py
@@ -41,6 +41,7 @@ class MutationRootType(graphene.ObjectType):
 
 
 schema = graphene.Schema(query=QueryRootType, mutation=MutationRootType)
+print schema
 
 graphql_application.config['graphql_schema'] = schema
 graphql_application.config['graphql_pretty'] = True
@@ -164,9 +165,9 @@ class TestGraphQLHandler(BaseTest):
             self.assertEqual(response.status_int, 400)
 
             expected = {
-                'errors': [{'locations': [{'column': 1, 'line': 1}],
-                            'message': 'Syntax Error GraphQL request (1:1) '
-                                       'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n'}]
+                u'errors': [{u'locations': [{u'column': 1, u'line': 1}],
+                            u'message': u'Syntax Error GraphQL (1:1) '
+                                        u'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n'}]
             }
             response_dict = json.loads(response.body)
             self.assertEqual(response_dict, expected)

--- a/tests/_webapp2/test_graphql_handler.py
+++ b/tests/_webapp2/test_graphql_handler.py
@@ -41,7 +41,6 @@ class MutationRootType(graphene.ObjectType):
 
 
 schema = graphene.Schema(query=QueryRootType, mutation=MutationRootType)
-print schema
 
 graphql_application.config['graphql_schema'] = schema
 graphql_application.config['graphql_pretty'] = True


### PR DESCRIPTION
Note:
When using graphene Interfaces, previous implementation could
display false positives by only checking if the root type matches
with the given model. Now if you pass in an Interface type, the
check will check that the object type's class hierarchy is a subset of
the instance's class hierarchy