### PR TITLE
Pin graphene

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'six>=1.10.0',
     'inflect==0.2.5',
-    'graphene>=2.0',
+    'graphene>=2.0,<3',
     'iso8601'
 ]
 


### PR DESCRIPTION
Graphene v3 will be released soon and it will contain breaking changes. This PR pins Graphene to versions less than 3 so that it doesn't accidentally install v3 until the library can support it.